### PR TITLE
Updated the usage tab hint text

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -167,7 +167,7 @@
             <div>
               <div class="section-kicker">Usage</div>
               <h1>Request and token usage by model and provider.</h1>
-              <p>Aggregated from non-streaming requests only. Streaming calls are not counted yet.</p>
+              <p>The gateway records usage for both streaming and non-streaming requests.</p>
             </div>
           </div>
 


### PR DESCRIPTION
Issue #12

Update usage tab hint text to reflect that streaming requests are now recorded.

Previously, the hint indicated that only non-streaming requests were counted, but now the gateway records usage for both streaming and non-streaming requests.