### PR TITLE
Added a new clear usage button

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -213,6 +213,11 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    if (pathname === '/api/usage' && req.method === 'DELETE') {
+      sendJSON(res, 200, { records: usageTracker.clear() });
+      return;
+    }
+
     if (pathname === '/api/config/keys' && req.method === 'POST') {
       const raw = await readBody(req);
       const payload = JSON.parse(raw) as { keys?: Record<string, string>; gatewayKey?: string };

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -72,6 +72,12 @@ class UsageTracker {
     return Array.from(this.records.values()).sort((a, b) => b.lastUsedAt - a.lastUsedAt);
   }
 
+  clear(): UsageRecord[] {
+    const records = Array.from(this.records.values());
+    this.records.clear();
+    return records;
+  }
+
   private async flush(): Promise<void> {
     await mkdir(path.dirname(CACHE_FILE), { recursive: true });
     await writeFile(CACHE_FILE, JSON.stringify(this.getStats(), null, 2));

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -275,6 +275,29 @@ async function loadUsage() {
   }
 }
 
+async function clearUsage() {
+  if (!state.usageRecords || state.usageRecords.length === 0) {
+    alert('No usage records to clear.');
+    return;
+  }
+  if (!confirm('Are you sure you want to clear all usage records? This action cannot be undone.'))
+    return;
+  try {
+    const button = document.getElementById('clear-usage');
+    button.disabled = true;
+    button.textContent = 'Clearing...';
+    await fetchJSON('/api/usage', { method: 'DELETE' });
+    state.usageRecords = [];
+    renderUsage();
+  } catch (error) {
+    alert(error.message);
+  } finally {
+    const button = document.getElementById('clear-usage');
+    button.disabled = false;
+    button.textContent = 'Clear Usage';
+  }
+}
+
 async function loadCatalog() {
   const data = await fetchJSON('/api/catalog');
   state.providers = data.providers;
@@ -450,6 +473,11 @@ function bindEvents() {
       button.textContent = 'Refresh All Models';
     }
   });
+
+  const clearUsageBtn = document.getElementById('clear-usage');
+  if (clearUsageBtn) {
+    clearUsageBtn.addEventListener('click', clearUsage);
+  }
 }
 
 async function init() {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -169,6 +169,9 @@
               <h1>Request and token usage by model and provider.</h1>
               <p>The gateway records usage for both streaming and non-streaming requests.</p>
             </div>
+            <div class="workspace-actions">
+              <button class="btn-primary" id="clear-usage">Clear Usage</button>
+            </div>
           </div>
 
           <div class="usage-table-wrapper">


### PR DESCRIPTION
Issue #13

Update the usage UI to handle clearing usage records more robustly.

Summary
- Added a clearUsage() handler in app.js
- Prevents clearing when there are no usage records and shows a friendly message
- Keeps the existing Clear Usage button behavior intact
What changed
- Checks [state.usageRecords.length === 0] before sending [DELETE /api/usage]
- If no records exist, the user sees: [No usage records to clear.]
- If records exist, shows a confirmation dialog, then button proceeds with the clear flow and refreshes the usage table