### PR TITLE
fix: parallel provider health checks using Promise.allSettled

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -174,13 +174,29 @@ export async function checkProviderHealth(providerName: string): Promise<Provide
 }
 
 export async function checkAllProvidersHealth(): Promise<ProviderHealth[]> {
-  const results: ProviderHealth[] = [];
-  for (const provider of providers) {
-    results.push(await checkProviderHealth(provider.name));
-  }
-  return results;
-}
+  const results = await Promise.allSettled(
+    providers.map((provider) => checkProviderHealth(provider.name))
+  );
 
+  return results.map((result, index): ProviderHealth => {
+    const provider = providers[index]; // 
+    if (result.status === "fulfilled") {
+      return result.value;
+    } else {
+      const reason = (result as PromiseRejectedResult).reason;
+      return {
+        provider: provider.name, // 
+        state: "unhealthy" as const,
+        message: String(reason),
+        checkedAt: Date.now(),
+        latencyMs: 0,
+        lastStatusCode: null,
+        lastError: String(reason),
+        lastSuccessAt: null,
+      };
+    }
+  });
+}
 export function getHealthSummary(): HealthSummary {
   const items = getAllProviderHealth();
   const summary: HealthSummary = {


### PR DESCRIPTION
## What I fixed

Earlier, provider health checks were running sequentially. If one provider failed or was slow, it affected the overall response time.

This change updates the logic to run all provider checks in parallel using Promise.allSettled. Now all providers are checked at the same time, and failures do not stop other checks.
## Improvements
* Faster health checks due to parallel execution
* Better error handling without early termination
* Consistent response even if some providers fail
## How to run locally
npm install
npm run build
npm start
Test the API:
POST http://localhost:8787/api/health/check-all
PowerShell:
Invoke-RestMethod -Uri http://localhost:8787/api/health/check-all -Method POST
##Note
If API keys are not configured, providers may return "missing_key", which is expected.
