### PR TITLE
docs: add OpenCode setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Freeway exposes **both** OpenAI and Anthropic compatible endpoints, so most codi
 
 > Detailed per-agent setup guides are available in [`docs/agents/`](./docs/agents/).
 
+- [OpenCode setup guide](./docs/agents/opencode.md)
+
 ### Claude Code
 
 Set the base URL to Freeway:

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -1,0 +1,22 @@
+## OpenCode Setup Guide
+
+Follow these steps to connect OpenCode to Freeway.
+
+### 1. Set environment variables
+
+```bash
+export OPENAI_BASE_URL=http://localhost:8787/v1
+export OPENAI_API_KEY=<your FREEWAY_API_KEY>
+```
+
+### 2. Start OpenCode normally
+
+OpenCode will use the configured OpenAI-compatible endpoint and forward requests through Freeway.
+
+### 3. Pick a model
+
+Use any Freeway model ID that is currently available in the local model catalog. Good starting options are the fast models marked healthy in the Freeway console.
+
+### 4. Verify setup
+
+Run a simple prompt in OpenCode, then check Freeway's **Usage** tab to verify the request was recorded.


### PR DESCRIPTION
Fixes #6

Adds a dedicated OpenCode guide and links it from the main README.

## Testing

- npm run build