### PR TITLE
docs: add Cline setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Freeway exposes **both** OpenAI and Anthropic compatible endpoints, so most codi
 
 > Detailed per-agent setup guides are available in [`docs/agents/`](./docs/agents/).
 
+- [Cline setup guide](./docs/agents/cline.md)
+
 ### Claude Code
 
 Set the base URL to Freeway:

--- a/docs/agents/cline.md
+++ b/docs/agents/cline.md
@@ -1,0 +1,25 @@
+## Cline Setup Guide
+
+Follow these steps to connect the Cline VS Code extension to Freeway.
+
+### 1. Open Cline provider settings
+
+In VS Code, open Cline settings and switch it to an OpenAI-compatible provider.
+
+### 2. Fill in the connection values
+
+Use these values in the provider form:
+
+- Base URL: `http://localhost:8787/v1`
+- API key: your `FREEWAY_API_KEY`
+- Model: any Freeway model ID from the model catalog
+
+Recommended starter models:
+
+- `llama-3.3-70b`
+- `gpt-4.1-mini` if your catalog exposes it
+- any fast free model currently marked healthy in the Freeway console
+
+### 3. Verify setup
+
+Ask Cline for a short response, then check the Freeway web console **Usage** tab to confirm the request was recorded.


### PR DESCRIPTION
Fixes #7

Adds a dedicated Cline guide and links it from the main README.

## Testing

- npm run build