### PR TITLE
docs: add Codex CLI setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Freeway exposes **both** OpenAI and Anthropic compatible endpoints, so most codi
 
 > Detailed per-agent setup guides are available in [`docs/agents/`](./docs/agents/).
 
+- [Codex CLI setup guide](./docs/agents/codex.md)
+
 ### Claude Code
 
 Set the base URL to Freeway:

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -1,0 +1,24 @@
+## Codex CLI Setup Guide
+
+Follow these steps to connect Codex CLI to Freeway.
+
+### 1. Set environment variables
+
+```bash
+export OPENAI_BASE_URL=http://localhost:8787/v1
+export OPENAI_API_KEY=<your FREEWAY_API_KEY>
+```
+
+### 2. Choose a model
+
+Codex CLI uses OpenAI-style model IDs, so point it at any model ID exposed by Freeway. For example:
+
+```bash
+export OPENAI_MODEL=llama-3.3-70b
+```
+
+If you prefer, you can also select the model in Codex CLI's own config flow, as long as the model name matches a Freeway catalog entry.
+
+### 3. Verify setup
+
+Run a simple Codex CLI request and confirm the request appears in Freeway's **Usage** tab or request logs.


### PR DESCRIPTION
Fixes #9

Adds a dedicated Codex CLI guide and links it from the main README.

## Testing

- npm run build