### PR TITLE
docs: add Aider setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Freeway exposes **both** OpenAI and Anthropic compatible endpoints, so most codi
 
 > Detailed per-agent setup guides are available in [`docs/agents/`](./docs/agents/).
 
+- [Aider setup guide](./docs/agents/aider.md)
+
 ### Claude Code
 
 Set the base URL to Freeway:

--- a/docs/agents/aider.md
+++ b/docs/agents/aider.md
@@ -1,0 +1,33 @@
+## Aider Setup Guide
+
+Follow these steps to connect Aider to Freeway.
+
+### 1. Start Freeway
+
+Make sure Freeway is running locally at `http://localhost:8787`.
+
+### 2. Point Aider at Freeway
+
+You can either pass flags directly:
+
+```bash
+aider --openai-api-base http://localhost:8787/v1 \
+  --openai-api-key "$FREEWAY_API_KEY" \
+  --model llama-3.3-70b
+```
+
+Or export the same values before running Aider:
+
+```bash
+export OPENAI_API_BASE=http://localhost:8787/v1
+export OPENAI_API_KEY=<your FREEWAY_API_KEY>
+aider --model llama-3.3-70b
+```
+
+### 3. Pick a model
+
+Use any Freeway model ID that appears in the local model catalog. A good starting point is `llama-3.3-70b`, then switch to another available model if you prefer.
+
+### 4. Verify setup
+
+Run a simple prompt in Aider, then open Freeway's **Usage** tab or request logs to confirm the call was routed through the gateway.


### PR DESCRIPTION
Fixes #10

Adds a dedicated Aider guide and links it from the main README.

## Testing

- npm run build