### PR TITLE
Implemented client side filtering in models tab

### DIFF
--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -369,6 +369,7 @@ function renderProviders() {
 
 function renderModels() {
   const search = document.getElementById('model-search').value.trim().toLowerCase();
+  const sortKey = document.getElementById('model-sort')?.value || 'name';
   const list = document.getElementById('models-list');
 
   const filtered = state.models.filter(model => {
@@ -380,7 +381,17 @@ function renderModels() {
     return matchesSearch;
   });
 
-  list.innerHTML = filtered.map(model => `
+  const sorted = filtered.slice().sort((a, b) => {
+    if (sortKey === 'context') {
+      return (b.context ?? 0) - (a.context ?? 0) || a.id.localeCompare(b.id);
+    }
+    if (sortKey === 'providers') {
+      return b.providers.length - a.providers.length || a.id.localeCompare(b.id);
+    }
+    return a.id.localeCompare(b.id);
+  });
+
+  list.innerHTML = sorted.map(model => `
     <div class="model-item">
       <div class="model-info">
         <div>
@@ -638,6 +649,7 @@ function setupTabs() {
 
 function bindEvents() {
   document.getElementById('model-search').addEventListener('input', renderModels);
+  document.getElementById('model-sort').addEventListener('change', renderModels);
   document.getElementById('provider-search').addEventListener('input', renderProviders);
   document.getElementById('provider-state-filter').addEventListener('change', renderProviders);
   document.getElementById('save-keys').addEventListener('click', saveKeys);

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -1318,6 +1318,29 @@ body {
   font-size: 0.72rem;
 }
 
+.toolbar select {
+  min-width: 180px;
+  padding-right: 2.6rem;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-primary) 50%),
+    linear-gradient(135deg, var(--text-primary) 50%, transparent 50%);
+  background-position: calc(100% - 1rem) center, calc(100% - 0.6rem) center;
+  background-size: 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.toolbar select::-ms-expand {
+  display: none;
+}
+
+.toolbar select option {
+  background: rgba(18, 18, 24, 0.96);
+  color: var(--text-primary);
+}
+
 .toolbar input {
   flex: 1;
 }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -153,6 +153,11 @@
           <div class="toolbar">
             <div class="toolbar-main">
               <input type="text" id="model-search" placeholder="Search models, providers, modality...">
+              <select id="model-sort">
+                <option value="name">Sort: Name</option>
+                <option value="context">Context size</option>
+                <option value="providers">Number of providers</option>
+              </select>
             </div>
           </div>
 


### PR DESCRIPTION
Issue #14

Add a sort dropdown to the Models tab and implement client-side sorting in renderModels().

- New sort options: Name, Context size, Number of providers
- Default sort remains alphabetical
- Dropdown change rerenders the model list
- Styled the dropdown to match the dashboard theme