### PR TITLE
add endpoint copy buttons

### DIFF
--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -651,14 +651,34 @@ async function copyText(value) {
   document.body.removeChild(textarea);
 }
 
+function getConsoleEndpointUrls() {
+  const origin = window.location.origin;
+  return {
+    openai: `${origin}/v1`,
+    anthropic: origin,
+  };
+}
+
+function renderConsoleEndpointUrls(endpoints) {
+  document.querySelectorAll('[data-endpoint-display]').forEach(element => {
+    const key = element.getAttribute('data-endpoint-display');
+    const endpoint = endpoints[key];
+    if (endpoint) element.textContent = endpoint;
+  });
+}
+
 function setupEndpointCopyButtons() {
   const feedback = document.getElementById('endpoint-copy-feedback');
-  const buttons = document.querySelectorAll('[data-copy-endpoint]');
+  const endpoints = getConsoleEndpointUrls();
+  const buttons = document.querySelectorAll('[data-copy-endpoint-key]');
   let feedbackTimer = 0;
+
+  renderConsoleEndpointUrls(endpoints);
 
   buttons.forEach(button => {
     button.addEventListener('click', async () => {
-      const endpoint = button.getAttribute('data-copy-endpoint');
+      const key = button.getAttribute('data-copy-endpoint-key');
+      const endpoint = endpoints[key];
       if (!endpoint) return;
 
       const previousText = button.textContent.trim() || 'Copy';

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -634,6 +634,58 @@ function formatNumber(value) {
   return String(value);
 }
 
+async function copyText(value) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+}
+
+function setupEndpointCopyButtons() {
+  const feedback = document.getElementById('endpoint-copy-feedback');
+  const buttons = document.querySelectorAll('[data-copy-endpoint]');
+  let feedbackTimer = 0;
+
+  buttons.forEach(button => {
+    button.addEventListener('click', async () => {
+      const endpoint = button.getAttribute('data-copy-endpoint');
+      if (!endpoint) return;
+
+      const previousText = button.textContent.trim() || 'Copy';
+      button.disabled = true;
+
+      try {
+        await copyText(endpoint);
+        button.textContent = 'Copied';
+        if (feedback) feedback.textContent = `Copied ${endpoint}`;
+      } catch {
+        button.textContent = 'Retry';
+        if (feedback) feedback.textContent = 'Copy failed';
+      } finally {
+        window.clearTimeout(feedbackTimer);
+        feedbackTimer = window.setTimeout(() => {
+          if (feedback) feedback.textContent = '';
+        }, 1400);
+
+        window.setTimeout(() => {
+          button.disabled = false;
+          button.textContent = previousText;
+        }, 1400);
+      }
+    });
+  });
+}
+
 function setupTabs() {
   const buttons = document.querySelectorAll('.tab-btn');
   const tabs = document.querySelectorAll('.tab-content');
@@ -648,6 +700,7 @@ function setupTabs() {
 }
 
 function bindEvents() {
+  setupEndpointCopyButtons();
   document.getElementById('model-search').addEventListener('input', renderModels);
   document.getElementById('model-sort').addEventListener('change', renderModels);
   document.getElementById('provider-search').addEventListener('input', renderProviders);

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -1091,6 +1091,9 @@ body {
   top: 84px;
   align-self: start;
   height: calc(100vh - 104px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   padding: 1rem;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -1224,6 +1227,82 @@ body {
   font-family: var(--font-mono);
   color: var(--green);
   font-weight: 500;
+}
+
+.endpoint-copy-card {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.endpoint-copy-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.endpoint-copy-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.45rem;
+  padding: 0.55rem;
+  border: 1px solid rgba(255,255,255,0.045);
+  border-radius: var(--radius-sm);
+  background: rgba(255,255,255,0.014);
+}
+
+.endpoint-copy-meta {
+  min-width: 0;
+}
+
+.endpoint-copy-meta span {
+  display: block;
+  margin-bottom: 0.18rem;
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.endpoint-copy-meta code {
+  display: block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.endpoint-copy-button {
+  justify-self: start;
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  font-weight: 600;
+  padding: 0.36rem 0.52rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(74,222,128,0.16);
+  background: rgba(74,222,128,0.06);
+  color: var(--green);
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s, color 0.2s;
+}
+
+.endpoint-copy-button:hover {
+  border-color: rgba(74,222,128,0.28);
+  background: rgba(74,222,128,0.1);
+  color: #86efac;
+}
+
+.endpoint-copy-button:disabled {
+  cursor: default;
+  opacity: 0.75;
+}
+
+.endpoint-copy-feedback {
+  min-height: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  color: var(--green);
 }
 
 /* ── Workspace Header ── */
@@ -1549,6 +1628,7 @@ textarea:focus-visible {
     position: relative;
     top: 0;
     height: auto;
+    overflow-y: visible;
   }
 
   .tabs.console-nav {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -100,6 +100,44 @@
             <strong>BYOK</strong>
           </div>
         </div>
+
+        <div class="sidebar-card endpoint-copy-card">
+          <div class="sidebar-card-label">Endpoints</div>
+
+          <div class="endpoint-copy-list">
+            <div class="endpoint-copy-row">
+              <div class="endpoint-copy-meta">
+                <span>OpenAI-compatible</span>
+                <code>http://localhost:8787/v1</code>
+              </div>
+              <button
+                class="endpoint-copy-button"
+                type="button"
+                data-copy-endpoint="http://localhost:8787/v1"
+                aria-label="Copy OpenAI-compatible endpoint URL"
+              >
+                Copy
+              </button>
+            </div>
+
+            <div class="endpoint-copy-row">
+              <div class="endpoint-copy-meta">
+                <span>Anthropic-compatible</span>
+                <code>http://localhost:8787</code>
+              </div>
+              <button
+                class="endpoint-copy-button"
+                type="button"
+                data-copy-endpoint="http://localhost:8787"
+                aria-label="Copy Anthropic-compatible endpoint URL"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+
+          <div class="endpoint-copy-feedback" id="endpoint-copy-feedback" aria-live="polite"></div>
+        </div>
       </aside>
 
       <!-- Main Workspace -->

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -108,12 +108,12 @@
             <div class="endpoint-copy-row">
               <div class="endpoint-copy-meta">
                 <span>OpenAI-compatible</span>
-                <code>http://localhost:8787/v1</code>
+                <code data-endpoint-display="openai"></code>
               </div>
               <button
                 class="endpoint-copy-button"
                 type="button"
-                data-copy-endpoint="http://localhost:8787/v1"
+                data-copy-endpoint-key="openai"
                 aria-label="Copy OpenAI-compatible endpoint URL"
               >
                 Copy
@@ -123,12 +123,12 @@
             <div class="endpoint-copy-row">
               <div class="endpoint-copy-meta">
                 <span>Anthropic-compatible</span>
-                <code>http://localhost:8787</code>
+                <code data-endpoint-display="anthropic"></code>
               </div>
               <button
                 class="endpoint-copy-button"
                 type="button"
-                data-copy-endpoint="http://localhost:8787"
+                data-copy-endpoint-key="anthropic"
                 aria-label="Copy Anthropic-compatible endpoint URL"
               >
                 Copy


### PR DESCRIPTION
 Closes #30

  Summary:
  - Display OpenAI-compatible and Anthropic-compatible local endpoint URLs in the console sidebar
  - Add copy buttons for both endpoint URLs
  - Show short copied-state feedback
  - Keep styling consistent with the existing console UI
  - Allow the left sidebar to scroll when content exceeds the viewport height

  Tests:
  - npm run build
  - npm run test:usage

  Screenshot:
  Attached below.
  
<img width="1440" height="1000" alt="free-way-endpoint-copy" src="https://github.com/user-attachments/assets/87a1b3ae-08a6-4615-8a33-18cc0761e11d" />
