### PR TITLE
feat: add copy-to-clipboard support for model IDs in Models tab

### DIFF
--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -428,18 +428,59 @@ function renderModels() {
     <div class="model-item">
       <div class="model-info">
         <div>
-          <div class="model-id">${model.id}</div>
-          <div class="provider-model-id">${model.providers.map(p => `${p.name}: ${p.providerModelId}`).join(' · ')}</div>
+          <div class="model-id-row">
+            <div class="model-id">${model.id}</div>
+            <button
+              class="copy-model-btn"
+              type="button"
+              data-copy-model-id="${model.id}"
+            >
+              Copy
+            </button>
+          </div>
+          <div class="provider-model-id">
+            ${model.providers.map(p => `${p.name}: ${p.providerModelId}`).join(' · ')}
+          </div>
         </div>
         <div class="model-provider">${model.providers.length} providers</div>
       </div>
+
       <div class="model-specs">
-        <div class="model-spec">Context <span>${model.context ? formatNumber(model.context) : '—'}</span></div>
-        <div class="model-spec">Output <span>${model.maxOutput ? formatNumber(model.maxOutput) : '—'}</span></div>
-        <div class="model-spec">Mode <span>${model.modality || '—'}</span></div>
+        <div class="model-spec">
+          Context <span>${model.context ? formatNumber(model.context) : '—'}</span>
+        </div>
+        <div class="model-spec">
+          Output <span>${model.maxOutput ? formatNumber(model.maxOutput) : '—'}</span>
+        </div>
+        <div class="model-spec">
+          Mode <span>${model.modality || '—'}</span>
+        </div>
       </div>
     </div>
   `).join('');
+
+  setTimeout(() => {
+    list.querySelectorAll('[data-copy-model-id]').forEach(button => {
+      button.addEventListener('click', async () => {
+        const modelId = button.getAttribute('data-copy-model-id');
+        const originalText = button.textContent;
+
+        button.disabled = true;
+
+        try {
+          await copyText(modelId);
+          button.textContent = 'Copied';
+        } catch {
+          button.textContent = 'Failed';
+        }
+
+        window.setTimeout(() => {
+          button.textContent = originalText;
+          button.disabled = false;
+        }, 1200);
+      });
+    });
+  }, 0);
 }
 
 function renderKeys() {


### PR DESCRIPTION
Summary:
Adds Copy buttons for canonical model IDs in the Models tab so users can quickly copy model names for clients, configs, and curl examples.

Features:
- Adds a Copy button for each canonical model ID
- Uses existing browser clipboard support via `copyText()`
- Shows lightweight success/failure feedback (`Copied` / `Failed`)
- Preserves existing model search and sorting behavior
- Keeps implementation dependency-free

Why:
This improves usability by making it faster to copy model IDs when configuring tools or testing requests.

Testing:
Tested manually by:
- Clicking Copy on multiple model IDs
- Verifying clipboard contents
- Confirming “Copied” feedback appears
- Confirming search still filters correctly
- Confirming sort options still work

Checklist:
- I kept the change focused and small
- I did not add new dependencies
- Existing functionality remains unchanged