### PR TITLE
feat: add styling for model ID copy buttons

### DIFF
--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -573,6 +573,38 @@ header .subtitle {
   margin-bottom: 0.25rem;
 }
 
+.model-id-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.copy-model-btn {
+  flex-shrink: 0;
+  padding: 0.28rem 0.65rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: var(--green);
+  background: rgba(74,222,128,0.06);
+  border: 1px solid rgba(74,222,128,0.18);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.copy-model-btn:hover {
+  background: rgba(74,222,128,0.1);
+  border-color: rgba(74,222,128,0.28);
+  color: #86efac;
+}
+
+.copy-model-btn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
 .provider-model-id {
   font-size: 0.68rem;
   color: var(--text-muted);


### PR DESCRIPTION
Summary:
Adds styling for model ID copy buttons in the Models tab to integrate the new copy-to-clipboard feature cleanly into the existing UI.

Features:
- Adds `.model-id-row` layout for proper alignment of model IDs and Copy buttons
- Styles `.copy-model-btn` to match existing console design
- Adds hover and disabled states for better UX feedback
- Preserves current model card spacing and readability
- Keeps implementation lightweight with no new dependencies

Why:
This improves usability and presentation by ensuring the new Copy model ID feature looks polished and consistent with the rest of the Free-Way interface.

Testing:
Tested manually by:
- Verifying Copy button alignment across model cards
- Confirming hover and disabled states display correctly
- Ensuring search and sorting layouts remain unchanged
- Checking visual consistency with existing dashboard styles

Checklist:
- I kept the change focused and small
- I did not add new dependencies
- Existing layout and functionality remain unchanged