### PR TITLE
 report skipped model refresh providersfix: report skipped model refresh providers

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -253,6 +253,14 @@ import { fetchZenMuxModels, mergeZenMuxWithAllowlist } from '../models/zenmux-sy
 
 const syncMeta = new Map<string, { updatedAt: number; source: string }>();
 
+type ProviderSyncStatus = 'refreshed' | 'skipped';
+
+export interface RefreshAllProviderModelsResult {
+  refreshed: string[];
+  failed: string[];
+  skipped: string[];
+}
+
 export function getProviderSyncMeta(providerName: string): { updatedAt: number; source: string } | undefined {
   return syncMeta.get(providerName);
 }
@@ -261,9 +269,9 @@ export function getAllSyncMetas(): Map<string, { updatedAt: number; source: stri
   return new Map(syncMeta);
 }
 
-async function syncProviderModels(provider: BaseProvider): Promise<void> {
+async function syncProviderModels(provider: BaseProvider): Promise<ProviderSyncStatus> {
   const apiKey = provider.apiKey;
-  if (!apiKey) return;
+  if (!apiKey) return 'skipped';
 
   if (provider.name === 'openrouter') {
     try {
@@ -281,7 +289,7 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
         console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
       }
     }
-    return;
+    return 'refreshed';
   }
 
   if (provider.name === 'cohere') {
@@ -305,7 +313,7 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
         console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
       }
     }
-    return;
+    return 'refreshed';
   }
 
   if (provider.name === 'github') {
@@ -329,14 +337,14 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
         console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
       }
     }
-    return;
+    return 'refreshed';
   }
 
   if (provider.name === 'cloudflare') {
     const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
     if (!accountId) {
       console.warn(`[${provider.name}] Missing CLOUDFLARE_ACCOUNT_ID environment variable`);
-      return;
+      return 'skipped';
     }
     try {
       const fetched = await fetchCloudflareModels(apiKey, accountId);
@@ -358,7 +366,7 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
         console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
       }
     }
-    return;
+    return 'refreshed';
   }
 
   if (provider.name === 'opencode') {
@@ -377,7 +385,7 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
         console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
       }
     }
-    return;
+    return 'refreshed';
   }
 
   if (provider.name === 'zenmux') {
@@ -401,7 +409,7 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
         console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
       }
     }
-    return;
+    return 'refreshed';
   }
 
   // Generic OpenAI-compatible provider
@@ -425,6 +433,7 @@ async function syncProviderModels(provider: BaseProvider): Promise<void> {
       console.log(`[${provider.name}] Fell back to cached ${cached.models.length} models`);
     }
   }
+  return 'refreshed';
 }
 
 export async function loadAllModelCaches(): Promise<void> {
@@ -477,18 +486,23 @@ export async function loadAllModelCaches(): Promise<void> {
   }
 }
 
-export async function refreshAllProviderModels(): Promise<{ refreshed: string[]; failed: string[] }> {
+export async function refreshAllProviderModels(): Promise<RefreshAllProviderModelsResult> {
   const refreshed: string[] = [];
   const failed: string[] = [];
+  const skipped: string[] = [];
 
   for (const provider of providers) {
     try {
-      await syncProviderModels(provider);
-      refreshed.push(provider.name);
+      const status = await syncProviderModels(provider);
+      if (status === 'skipped') {
+        skipped.push(provider.name);
+      } else {
+        refreshed.push(provider.name);
+      }
     } catch {
       failed.push(provider.name);
     }
   }
 
-  return { refreshed, failed };
+  return { refreshed, failed, skipped };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,6 +203,7 @@ const server = http.createServer(async (req, res) => {
         ok: true,
         refreshed: result.refreshed,
         failed: result.failed,
+        skipped: result.skipped,
         syncedAt: Date.now(),
       });
       return;
@@ -544,6 +545,9 @@ export async function startServer() {
     console.log(`[Sync] Refreshed: ${result.refreshed.join(', ')}`);
     if (result.failed.length) {
       console.warn(`[Sync] Failed: ${result.failed.join(', ')}`);
+    }
+    if (result.skipped.length) {
+      console.log(`[Sync] Skipped: ${result.skipped.join(', ')}`);
     }
   }).catch((err) => {
     console.error('[Sync] Background refresh failed:', err instanceof Error ? err.message : String(err));

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -4,6 +4,7 @@ const state = {
   healthSummary: null,
   syncMetas: {},
   usageRecords: [],
+  lastRefreshResult: null,
 };
 
 const healthLabels = {
@@ -80,6 +81,11 @@ function readOpenAIStreamEvents(buffer, flush = false) {
     text: events.map(extractOpenAIStreamContent).join(''),
     pending,
   };
+}
+
+function formatProviderNames(names) {
+  if (!Array.isArray(names) || names.length === 0) return 'none';
+  return names.join(', ');
 }
 
 function getRouteMeta(stateKey) {
@@ -528,14 +534,25 @@ function renderSyncMeta() {
   if (!root) return;
   const metas = state.syncMetas;
   const entries = Object.entries(metas);
+  const refreshResult = state.lastRefreshResult;
+  const refreshSummary = refreshResult
+    ? `Last refresh: ${refreshResult.refreshed?.length ?? 0} refreshed, ${refreshResult.skipped?.length ?? 0} skipped, ${refreshResult.failed?.length ?? 0} failed`
+    : '';
+
+  const details = refreshResult && ((refreshResult.skipped?.length ?? 0) > 0 || (refreshResult.failed?.length ?? 0) > 0)
+    ? `Skipped: ${formatProviderNames(refreshResult.skipped)} · Failed: ${formatProviderNames(refreshResult.failed)}`
+    : '';
+
+  const prefix = [refreshSummary, details].filter(Boolean).join(' · ');
   if (entries.length === 0) {
-    root.textContent = 'Models: using built-in lists';
+    root.textContent = [prefix, 'Models: using built-in lists'].filter(Boolean).join(' · ');
     return;
   }
-  root.innerHTML = entries.map(([name, meta]) => {
+  const metaHtml = entries.map(([name, meta]) => {
     const sourceLabel = meta.source === 'api' ? 'live' : 'cached';
     return `<span>${name}: ${sourceLabel} @ ${formatTime(meta.updatedAt)}</span>`;
   }).join(' · ');
+  root.innerHTML = [prefix ? `<span>${escapeHtml(prefix)}</span>` : '', metaHtml].filter(Boolean).join(' · ');
 }
 
 async function loadUsage() {
@@ -829,7 +846,7 @@ function bindEvents() {
     try {
       button.disabled = true;
       button.textContent = 'Syncing...';
-      await fetchJSON('/api/models/refresh', { method: 'POST' });
+      state.lastRefreshResult = await fetchJSON('/api/models/refresh', { method: 'POST' });
       await loadCatalog();
     } catch (error) {
       alert(error.message);


### PR DESCRIPTION
 ## Summary
  - Separate skipped providers from refreshed providers during model refresh
  - Add `skipped` to `/api/models/refresh` responses
  - Show refresh summary in the console sync metadata
  - Treat missing provider API keys and missing Cloudflare account ID as skipped

  Fixes #39

  ## Verification
  - npm run build

  Commit: 7abce19 fix: report skipped model refresh provider