### PR TITLE
docs: remove stray empty list item in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ Free-Way exposes **both** OpenAI and Anthropic compatible endpoints, so most cod
 > Detailed per-agent setup guides are available in [`docs/agents/`](./docs/agents/).
 
 - [OpenRouter Provider Setup](./docs/providers/openrouter.md)
-- 
 - [OpenCode setup guide](./docs/agents/opencode.md)
 - [Aider Integration Guide](./docs/agents/aider.md)
 


### PR DESCRIPTION
## Summary
- Remove stray empty `-` list item left by #53 in README

## Test plan
- Visual check: list renders without empty bullet