### PR TITLE
Provider timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Effective key precedence is:
 | Variable | Purpose |
 |---|---|
 | `FREEWAY_API_KEY` | Optional gateway auth key for clients calling Free-Way |
+| `FREEWAY_PROVIDER_TIMEOUT_MS` | Optional outbound provider request timeout in milliseconds (default: `30000`) |
 | `OPENROUTER_API_KEY` | OpenRouter key |
 | `GROQ_API_KEY` | Groq key |
 | `GITHUB_TOKEN` | GitHub Models token |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,6 +228,7 @@ export OPENAI_API_KEY=<你的 FREEWAY_API_KEY>
 | 变量名 | 作用 |
 |---|---|
 | `FREEWAY_API_KEY` | 可选，调用 Free-Way 时的网关鉴权密钥 |
+| `FREEWAY_PROVIDER_TIMEOUT_MS` | 可选，出站 Provider 请求超时时间，单位毫秒（默认：`30000`） |
 | `OPENROUTER_API_KEY` | OpenRouter 密钥 |
 | `GROQ_API_KEY` | Groq 密钥 |
 | `GITHUB_TOKEN` | GitHub Models Token |

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,10 +3,32 @@ import { getPersistedConfigPath, loadPersistedConfig, savePersistedConfig } from
 const runtimeApiKeys = new Map<string, string>();
 const persistedApiKeys = new Map<string, string>();
 
+export const DEFAULT_PROVIDER_TIMEOUT_MS = 30_000;
+
+const MAX_PROVIDER_TIMEOUT_MS = 2_147_483_647;
+
 let configMeta: { persistedPath: string | null; persistedUpdatedAt: number | null } = {
   persistedPath: null,
   persistedUpdatedAt: null,
 };
+
+export function resolveProviderTimeoutMs(value: string | number | undefined): number {
+  const raw = typeof value === 'string' ? value.trim() : value;
+  if (raw === undefined || raw === '') {
+    return DEFAULT_PROVIDER_TIMEOUT_MS;
+  }
+
+  const timeoutMs = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_PROVIDER_TIMEOUT_MS) {
+    return DEFAULT_PROVIDER_TIMEOUT_MS;
+  }
+
+  return timeoutMs;
+}
+
+export function getProviderTimeoutMs(): number {
+  return resolveProviderTimeoutMs(process.env.FREEWAY_PROVIDER_TIMEOUT_MS);
+}
 
 export function setRuntimeApiKey(envVar: string, value: string) {
   const trimmed = value.trim();

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,4 +1,5 @@
 import { providers } from './providers/index.js';
+import { fetchWithProviderTimeout } from './providers/timeout.js';
 
 export type ProviderHealthState = 'missing_key' | 'configured' | 'healthy' | 'unhealthy';
 
@@ -100,19 +101,23 @@ export async function checkProviderHealth(providerName: string): Promise<Provide
     let response: Response;
 
     if (provider.name === 'cohere') {
-      response = await fetch(`${provider.baseURL}/chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${provider.apiKey}`,
+      response = await fetchWithProviderTimeout(
+        { providerName: provider.name, operation: 'health check' },
+        `${provider.baseURL}/chat`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${provider.apiKey}`,
+          },
+          body: JSON.stringify({
+            model: sampleModel.providerModelId,
+            messages: [{ role: 'user', content: 'ping' }],
+            max_tokens: 8,
+            temperature: 0,
+          }),
         },
-        body: JSON.stringify({
-          model: sampleModel.providerModelId,
-          messages: [{ role: 'user', content: 'ping' }],
-          max_tokens: 8,
-          temperature: 0,
-        }),
-      });
+      );
     } else {
       response = await provider.chatCompletion({
         model: `${provider.name}/${sampleModel.id}`,

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,5 +1,6 @@
 import type { ChatCompletionRequest, ProviderModel } from '../types.js';
 import { getEffectiveApiKey } from '../config.js';
+import { fetchWithProviderTimeout } from './timeout.js';
 
 export interface ProviderConfig {
   name: string;
@@ -54,15 +55,19 @@ export abstract class BaseProvider {
     const url = `${this.baseURL}/chat/completions`;
     const body = this.transformRequest(request);
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.apiKey}`,
-        ...this.customHeaders,
+    const response = await fetchWithProviderTimeout(
+      { providerName: this.name, operation: 'chat completion' },
+      url,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+          ...this.customHeaders,
+        },
+        body: JSON.stringify(body),
       },
-      body: JSON.stringify(body),
-    });
+    );
 
     return response;
   }

--- a/src/providers/cohere.ts
+++ b/src/providers/cohere.ts
@@ -1,5 +1,6 @@
 import { BaseProvider, type ProviderConfig } from './base.js';
 import type { ChatCompletionRequest, ChatMessage } from '../types.js';
+import { withProviderTimeout } from './timeout.js';
 
 interface CohereMessage {
   role: 'user' | 'assistant' | 'system';
@@ -116,71 +117,77 @@ export class CohereProvider extends BaseProvider {
     if (request.tools) body.tools = request.tools;
     if (request.tool_choice) body.tool_choice = request.tool_choice;
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.apiKey}`,
-        ...this.customHeaders,
-      },
-      body: JSON.stringify(body),
-    });
+    return withProviderTimeout(
+      { providerName: this.name, operation: 'chat completion' },
+      async (signal) => {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+            ...this.customHeaders,
+          },
+          body: JSON.stringify(body),
+          signal,
+        });
 
-    if (request.stream) {
-      return response;
-    }
+        if (request.stream) {
+          return response;
+        }
 
-    const cohereData = (await response.json()) as CohereChatResponse;
+        const cohereData = (await response.json()) as CohereChatResponse;
 
-    let content = '';
-    if (cohereData.message?.content) {
-      if (typeof cohereData.message.content === 'string') {
-        content = cohereData.message.content;
-      } else {
-        content = cohereData.message.content.map((c) => c.text).join('');
+        let content = '';
+        if (cohereData.message?.content) {
+          if (typeof cohereData.message.content === 'string') {
+            content = cohereData.message.content;
+          } else {
+            content = cohereData.message.content.map((c) => c.text).join('');
+          }
+        } else if (cohereData.text) {
+          content = cohereData.text;
+        }
+
+        const tokens = cohereData.usage?.tokens ?? cohereData.usage?.billed_units;
+        const toolCalls = Array.isArray(cohereData.message?.tool_calls)
+          ? cohereData.message?.tool_calls
+          : undefined;
+
+        const message: Record<string, unknown> = { role: 'assistant', content };
+        if (toolCalls?.length) {
+          message.tool_calls = toolCalls;
+        }
+
+        const finishReason = toolCalls?.length
+          ? 'tool_calls'
+          : cohereData.finish_reason === 'COMPLETE'
+            ? 'stop'
+            : cohereData.finish_reason ?? 'stop';
+
+        const openAIResponse = {
+          id: cohereData.id ?? cohereData.generation_id ?? `cohere-${Date.now()}`,
+          object: 'chat.completion',
+          created: Math.floor(Date.now() / 1000),
+          model: request.model,
+          choices: [
+            {
+              index: 0,
+              message,
+              finish_reason: finishReason,
+            },
+          ],
+          usage: {
+            prompt_tokens: tokens?.input_tokens ?? 0,
+            completion_tokens: tokens?.output_tokens ?? 0,
+            total_tokens: (tokens?.input_tokens ?? 0) + (tokens?.output_tokens ?? 0),
+          },
+        };
+
+        return new Response(JSON.stringify(openAIResponse), {
+          status: response.status,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
-    } else if (cohereData.text) {
-      content = cohereData.text;
-    }
-
-    const tokens = cohereData.usage?.tokens ?? cohereData.usage?.billed_units;
-    const toolCalls = Array.isArray(cohereData.message?.tool_calls)
-      ? cohereData.message?.tool_calls
-      : undefined;
-
-    const message: Record<string, unknown> = { role: 'assistant', content };
-    if (toolCalls?.length) {
-      message.tool_calls = toolCalls;
-    }
-
-    const finishReason = toolCalls?.length
-      ? 'tool_calls'
-      : cohereData.finish_reason === 'COMPLETE'
-        ? 'stop'
-        : cohereData.finish_reason ?? 'stop';
-
-    const openAIResponse = {
-      id: cohereData.id ?? cohereData.generation_id ?? `cohere-${Date.now()}`,
-      object: 'chat.completion',
-      created: Math.floor(Date.now() / 1000),
-      model: request.model,
-      choices: [
-        {
-          index: 0,
-          message,
-          finish_reason: finishReason,
-        },
-      ],
-      usage: {
-        prompt_tokens: tokens?.input_tokens ?? 0,
-        completion_tokens: tokens?.output_tokens ?? 0,
-        total_tokens: (tokens?.input_tokens ?? 0) + (tokens?.output_tokens ?? 0),
-      },
-    };
-
-    return new Response(JSON.stringify(openAIResponse), {
-      status: response.status,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    );
   }
 }

--- a/src/providers/timeout.ts
+++ b/src/providers/timeout.ts
@@ -1,0 +1,90 @@
+import { getProviderTimeoutMs, resolveProviderTimeoutMs } from '../config.js';
+
+const DEFAULT_PROVIDER_OPERATION = 'provider request';
+
+export class ProviderTimeoutError extends Error {
+  readonly providerName: string;
+  readonly operation: string;
+  readonly timeoutMs: number;
+
+  constructor(providerName: string, operation: string, timeoutMs: number) {
+    super(`Provider "${providerName}" timed out after ${timeoutMs}ms during ${operation}`);
+    this.name = 'ProviderTimeoutError';
+    this.providerName = providerName;
+    this.operation = operation;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export interface ProviderTimeoutOptions {
+  providerName: string;
+  operation?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal | null;
+}
+
+type ProviderFetchTimeoutOptions = Omit<ProviderTimeoutOptions, 'signal'>;
+
+function linkAbortSignal(
+  source: AbortSignal | null | undefined,
+  controller: AbortController,
+): (() => void) | undefined {
+  if (!source) {
+    return undefined;
+  }
+
+  if (source.aborted) {
+    controller.abort(source.reason);
+    return undefined;
+  }
+
+  const abort = () => controller.abort(source.reason);
+  source.addEventListener('abort', abort, { once: true });
+
+  return () => source.removeEventListener('abort', abort);
+}
+
+export async function withProviderTimeout<T>(
+  options: ProviderTimeoutOptions,
+  task: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const timeoutMs = options.timeoutMs === undefined
+    ? getProviderTimeoutMs()
+    : resolveProviderTimeoutMs(options.timeoutMs);
+  const operation = options.operation ?? DEFAULT_PROVIDER_OPERATION;
+  const controller = new AbortController();
+  const timeoutError = new ProviderTimeoutError(options.providerName, operation, timeoutMs);
+  let timedOut = false;
+
+  const unlinkAbortSignal = linkAbortSignal(options.signal, controller);
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort(timeoutError);
+  }, timeoutMs);
+
+  try {
+    return await task(controller.signal);
+  } catch (error) {
+    if (timedOut) {
+      throw timeoutError;
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+    unlinkAbortSignal?.();
+  }
+}
+
+export function fetchWithProviderTimeout(
+  options: ProviderFetchTimeoutOptions,
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const { signal, ...fetchInit } = init;
+
+  return withProviderTimeout(
+    { ...options, signal },
+    (timeoutSignal) => fetch(input, { ...fetchInit, signal: timeoutSignal }),
+  );
+}


### PR DESCRIPTION
# Add timeout support for provider requests

Closes #33

## Summary

This PR adds timeout handling for outbound provider requests so a slow or hanging provider does not block Free-Way indefinitely.

The implementation keeps the scope intentionally focused on timeout behavior, in line with the issue request. It does not introduce broader retry logic, circuit breakers, provider scoring, or streaming idle-timeout behavior.

## What changed

- Added a centralized provider timeout configuration:
  - Default timeout: `30000ms`
  - Optional environment variable: `FREEWAY_PROVIDER_TIMEOUT_MS`
  - Invalid timeout values safely fall back to the default

- Added a shared timeout helper based on `AbortController`:
  - `ProviderTimeoutError`
  - `withProviderTimeout()`
  - `fetchWithProviderTimeout()`

- Applied timeout handling to provider requests:
  - `BaseProvider.chatCompletion()`
  - `CohereProvider.chatCompletion()`

- Applied timeout handling to Cohere health checks:
  - Timed-out health checks are marked as `unhealthy`
  - Timeout messages include the provider name, timeout duration, and operation

- Documented `FREEWAY_PROVIDER_TIMEOUT_MS` in:
  - `README.md`
  - `README.zh-CN.md`

## Behavior

When a provider exceeds the configured timeout, the request is aborted and a clear error is raised, for example:

```text
Provider "cohere" timed out after 30000ms during health check
```

This allows the existing router fallback behavior to continue working without changing the router logic.

## Scope

This PR intentionally avoids adding:

- Advanced retry behavior
- Backoff logic
- Circuit-breaker behavior
- Provider health scoring
- Streaming idle timeout handling

Those can be handled separately if needed. This PR focuses only on preventing provider requests from hanging indefinitely.

## Validation

- [x] `npm run build` passes
- [x] Timeout with `AbortController` validated using a simulated hanging `fetch`
- [x] Router fallback validated: a slow provider timed out and the router successfully returned a response from a fast provider with status `200`
- [x] Cohere health check timeout validated:
  - Provider was marked as `unhealthy`
  - Error message was clear:
    ```text
    Provider "cohere" timed out after 20ms during health check
    ```

## Acceptance criteria

- [x] A timed-out provider does not hang the whole request indefinitely
- [x] Timeout errors are clear enough for troubleshooting
- [x] Fallback behavior is preserved
- [x] `npm run build` passes
