### PR TITLE
Add usage totals summary to console

### DIFF
--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -503,7 +503,46 @@ function renderTestModelOptions() {
     .join('');
 }
 
+function toUsageNumber(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function getUsageTotals(records) {
+  return (Array.isArray(records) ? records : []).reduce((totals, record) => {
+    const promptTokens = toUsageNumber(record.promptTokens);
+    const completionTokens = toUsageNumber(record.completionTokens);
+
+    totals.callCount += toUsageNumber(record.callCount);
+    totals.promptTokens += promptTokens;
+    totals.completionTokens += completionTokens;
+    totals.totalTokens += toUsageNumber(record.totalTokens ?? promptTokens + completionTokens);
+
+    return totals;
+  }, {
+    callCount: 0,
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+  });
+}
+
+function setTextContent(id, value) {
+  const element = document.getElementById(id);
+  if (element) element.textContent = value;
+}
+
+function renderUsageSummary() {
+  const totals = getUsageTotals(state.usageRecords);
+
+  setTextContent('usage-total-calls', formatNumber(totals.callCount));
+  setTextContent('usage-total-prompt-tokens', formatNumber(totals.promptTokens));
+  setTextContent('usage-total-completion-tokens', formatNumber(totals.completionTokens));
+  setTextContent('usage-total-tokens', formatNumber(totals.totalTokens));
+}
+
 function renderUsage() {
+  renderUsageSummary();
   const tbody = document.getElementById('usage-table-body');
   const records = state.usageRecords;
   if (!records || records.length === 0) {

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -863,6 +863,42 @@ header .subtitle {
 }
 
 /* ── Usage Table ── */
+.usage-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.usage-summary-card {
+  padding: 1rem 1.15rem;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.025), var(--card-shadow);
+}
+
+.usage-summary-title {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.35rem;
+}
+
+.usage-summary-value {
+  font-family: var(--font-mono);
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.1;
+}
+
+.usage-summary-value.highlight {
+  color: var(--green);
+}
+
 .usage-table-wrapper {
   overflow-x: auto;
   border: 1px solid var(--border-subtle);
@@ -928,6 +964,18 @@ header .subtitle {
   font-family: var(--font-mono);
   font-size: 0.65rem;
   color: var(--green);
+}
+
+@media (max-width: 880px) {
+  .usage-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .usage-summary {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── Footer ── */

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -217,6 +217,25 @@
             </div>
           </div>
 
+          <section class="usage-summary" id="usage-summary" aria-label="Usage totals">
+            <div class="usage-summary-card">
+              <div class="usage-summary-title">Total Calls</div>
+              <div class="usage-summary-value" id="usage-total-calls">0</div>
+            </div>
+            <div class="usage-summary-card">
+              <div class="usage-summary-title">Prompt Tokens</div>
+              <div class="usage-summary-value" id="usage-total-prompt-tokens">0</div>
+            </div>
+            <div class="usage-summary-card">
+              <div class="usage-summary-title">Completion Tokens</div>
+              <div class="usage-summary-value" id="usage-total-completion-tokens">0</div>
+            </div>
+            <div class="usage-summary-card">
+              <div class="usage-summary-title">Total Tokens</div>
+              <div class="usage-summary-value highlight" id="usage-total-tokens">0</div>
+            </div>
+          </section>
+
           <div class="usage-table-wrapper">
             <table class="usage-table" id="usage-table">
               <thead>


### PR DESCRIPTION
 Closes #36

  Summary:
  - Added a totals summary above the Usage table
  - Computes total calls, prompt tokens, completion tokens, and total tokens from state.usageRecords
  - Empty usage state shows zero totals
  - Backend /api/usage response shape is unchanged

  Test:
  - npm run build