### PR TITLE
fix: return 400 for malformed JSON bodies (#32)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -91,6 +91,19 @@ async function readBody(req: http.IncomingMessage): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8');
 }
 
+type JsonBodyParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false };
+
+function parseJsonBody<T>(raw: string, res: http.ServerResponse): JsonBodyParseResult<T> {
+  try {
+    return { ok: true, value: JSON.parse(raw) as T };
+  } catch {
+    sendJSON(res, 400, { error: { message: 'Invalid JSON body', type: 'invalid_request_error' } });
+    return { ok: false };
+  }
+}
+
 async function serveStatic(url: string, res: http.ServerResponse): Promise<boolean> {
   if (url === '/' || url === '/index.html') {
     const html = await readFile(path.join(WEB_ROOT, 'templates', 'index.html'), 'utf-8');
@@ -221,7 +234,9 @@ const server = http.createServer(async (req, res) => {
 
     if (pathname === '/api/config/keys' && req.method === 'POST') {
       const raw = await readBody(req);
-      const payload = JSON.parse(raw) as { keys?: Record<string, string>; gatewayKey?: string };
+      const parsedBody = parseJsonBody<{ keys?: Record<string, string>; gatewayKey?: string }>(raw, res);
+      if (!parsedBody.ok) return;
+      const payload = parsedBody.value;
       const keys = payload.keys ?? {};
       const updated: string[] = [];
       const ignored: string[] = [];
@@ -270,7 +285,9 @@ const server = http.createServer(async (req, res) => {
     if (pathname === '/v1/chat/completions' && req.method === 'POST') {
       if (!checkGatewayAuth(req, res)) return;
       const raw = await readBody(req);
-      const request = JSON.parse(raw) as ChatCompletionRequest;
+      const parsedBody = parseJsonBody<ChatCompletionRequest>(raw, res);
+      if (!parsedBody.ok) return;
+      const request = parsedBody.value;
 
       trace('openai.request', {
         model: request.model ?? null,
@@ -387,7 +404,9 @@ const server = http.createServer(async (req, res) => {
     if (pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
       if (!checkGatewayAuth(req, res)) return;
       const raw = await readBody(req);
-      const payload = JSON.parse(raw) as Record<string, unknown>;
+      const parsedBody = parseJsonBody<Record<string, unknown>>(raw, res);
+      if (!parsedBody.ok) return;
+      const payload = parsedBody.value;
       const result = estimateAnthropicCountTokens({
         messages: payload.messages,
         system: payload.system,
@@ -400,7 +419,9 @@ const server = http.createServer(async (req, res) => {
     if (pathname === '/v1/messages' && req.method === 'POST') {
       if (!checkGatewayAuth(req, res)) return;
       const raw = await readBody(req);
-      const anthropicReq = JSON.parse(raw) as AnthropicRequest;
+      const parsedBody = parseJsonBody<AnthropicRequest>(raw, res);
+      if (!parsedBody.ok) return;
+      const anthropicReq = parsedBody.value;
 
       trace('anthropic.request', {
         model: anthropicReq.model ?? null,


### PR DESCRIPTION
# Return 400 for malformed JSON request bodies

Closes #32

## Summary

This PR fixes malformed JSON handling for request bodies in `src/server.ts`.

Previously, several routes parsed request bodies with `JSON.parse(raw)` directly. When the request body contained malformed JSON, the thrown parsing error fell through to the top-level error handler and returned a generic HTTP `500`.

Malformed JSON is a client request error, so these routes now return HTTP `400` with an OpenAI-style `invalid_request_error` response.

## What Changed

- Added a shared JSON body parsing helper.
- Safely wrapped request body parsing in `try/catch`.
- Returned HTTP `400` when JSON parsing fails.
- Preserved the existing behavior for valid JSON requests.

## Routes Updated

- `POST /v1/chat/completions`
- `POST /v1/messages`
- `POST /v1/messages/count_tokens`
- `POST /api/config/keys`

## Error Response

Malformed JSON now returns:

```json
{
  "error": {
    "message": "Invalid JSON body",
    "type": "invalid_request_error"
  }
}
```

## Validation

The build was validated with:

```bash
cmd /c npm run build
```

Result:

```text
> freeway@0.1.0 build
> tsc
```

HTTP smoke tests were also run against a temporary local server.

Malformed JSON was tested against:

- `POST /v1/chat/completions`
- `POST /v1/messages`
- `POST /v1/messages/count_tokens`
- `POST /api/config/keys`

Each route returned HTTP `400` with:

```json
{
  "error": {
    "message": "Invalid JSON body",
    "type": "invalid_request_error"
  }
}
```

Valid JSON requests were also tested to confirm the existing request flow still works as before.

## Requirements

- [x] Safely parse JSON request bodies.
- [x] Return HTTP `400` for malformed JSON.
- [x] Use an OpenAI-style error shape where appropriate.

## Acceptance Criteria

- [x] Malformed JSON no longer returns HTTP `500`.
- [x] Valid requests continue to work as before.
- [x] `npm run build` passes.
- [x] The PR stays focused on request parsing/error handling.

## Scope

This PR only changes request body parsing and malformed JSON error handling.

It does not change:

- Routing behavior
- Provider selection
- Retry logic
- Timeout behavior
- Streaming behavior
- Provider response parsing