### PR TITLE
fix: harden local management API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ Effective key precedence is:
 2. Environment variable
 3. Persisted `.freeway/config.json`
 
+### Local security model
+
+Free-Way binds to `127.0.0.1` by default. Set `HOST=0.0.0.0` only if you intentionally want LAN access.
+
+Browser CORS is limited to same-machine localhost origins. Management endpoints such as key configuration, model refresh, provider health checks, and usage clearing reject non-local browser origins. If `FREEWAY_API_KEY` is configured, those management endpoints and `/v1/*` API calls must include `Authorization: Bearer <FREEWAY_API_KEY>` or `x-api-key: <FREEWAY_API_KEY>`.
+
 ### Common environment variables
 
 | Variable | Purpose |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Free-Way</h1>
 
 <p align="center">
-  <strong>Use Claude Code, Codex, OpenCode, Cline for free — one gateway to 14+ free LLM providers.</strong>
+  <strong>Use Claude Code, Codex, OpenCode, Continue, and Cline for free with your own free-tier LLM provider keys.</strong>
 </p>
 
 <p align="center">
@@ -24,8 +24,8 @@
 </p>
 
 <p align="center">
-  Bring your own provider keys. Free-Way exposes OpenAI- and Anthropic-compatible endpoints,
-  discovers models, routes requests, and falls back across compatible free-tier providers.
+  One localhost gateway for OpenAI- and Anthropic-compatible tools.
+  Bring your own keys. No hosted proxy. No shared key pool.
   Your tools keep one base URL: <code>http://localhost:8787</code>.
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 <h1 align="center">Free-Way</h1>
 
 <p align="center">
-  <strong>免费使用 Claude Code、Codex、OpenCode、Cline — 一个网关对接 14+ 免费 LLM 提供商。</strong>
+  <strong>用你自己的免费额度 LLM Provider Key，免费接入 Claude Code、Codex、OpenCode、Continue 和 Cline。</strong>
 </p>
 
 <p align="center">
@@ -24,8 +24,8 @@
 </p>
 
 <p align="center">
-  自备 Provider Key。Free-Way 暴露 OpenAI / Anthropic 兼容接口，
-  负责模型发现、请求路由和兼容 Provider 间的自动回退。
+  一个 localhost 网关，兼容 OpenAI / Anthropic 工具。
+  自备 Key，不托管代理，不共享 Key 池。
   你的工具只需要一个 base URL：<code>http://localhost:8787</code>。
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,6 +223,12 @@ export OPENAI_API_KEY=<你的 FREEWAY_API_KEY>
 2. 环境变量
 3. 持久化文件 `.freeway/config.json`
 
+### 本地安全模型
+
+Free-Way 默认只监听 `127.0.0.1`。只有在你明确需要局域网访问时，才建议设置 `HOST=0.0.0.0`。
+
+浏览器 CORS 默认只允许本机 localhost 来源。密钥配置、模型刷新、Provider 健康检查、清空 usage 等管理接口会拒绝非本机浏览器来源。如果配置了 `FREEWAY_API_KEY`，这些管理接口和 `/v1/*` 调用都需要提供 `Authorization: Bearer <FREEWAY_API_KEY>` 或 `x-api-key: <FREEWAY_API_KEY>`。
+
 ### 常用环境变量
 
 | 变量名 | 作用 |

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test:compat": "npm run build && node scripts/compat-regression.mjs",
+    "test:security": "npm run build && node scripts/security-regression.mjs",
     "test:usage": "npm run build && node scripts/usage-regression.mjs"
   },
   "keywords": [

--- a/scripts/security-regression.mjs
+++ b/scripts/security-regression.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { createServer } from '../dist/server.js';
+import { setFreewayApiKey } from '../dist/config.js';
+
+setFreewayApiKey('secret');
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const address = server.address();
+      assert(address && typeof address === 'object');
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+const server = createServer({
+  routeChatCompletion: async () => {
+    throw new Error('security regression should not route chat completions');
+  },
+});
+const baseUrl = await listen(server);
+const localOrigin = baseUrl;
+
+try {
+  const evilPreflight = await fetch(`${baseUrl}/api/config/keys`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: 'https://evil.example',
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'content-type',
+    },
+  });
+  assert.equal(evilPreflight.status, 403);
+  assert.equal(evilPreflight.headers.get('access-control-allow-origin'), null);
+
+  const evilWrite = await fetch(`${baseUrl}/api/config/keys`, {
+    method: 'POST',
+    headers: {
+      Origin: 'https://evil.example',
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer secret',
+    },
+    body: JSON.stringify({ keys: {} }),
+  });
+  assert.equal(evilWrite.status, 403);
+  assert.equal(evilWrite.headers.get('access-control-allow-origin'), null);
+
+  const localNoAuth = await fetch(`${baseUrl}/api/usage`, {
+    method: 'DELETE',
+    headers: { Origin: localOrigin },
+  });
+  assert.equal(localNoAuth.status, 401);
+  assert.equal(localNoAuth.headers.get('access-control-allow-origin'), localOrigin);
+
+  const localAuthed = await fetch(`${baseUrl}/api/usage`, {
+    method: 'DELETE',
+    headers: {
+      Origin: localOrigin,
+      Authorization: 'Bearer secret',
+    },
+  });
+  assert.equal(localAuthed.status, 200);
+  assert.equal(localAuthed.headers.get('access-control-allow-origin'), localOrigin);
+
+  const publicHealth = await fetch(`${baseUrl}/health`, {
+    headers: { Origin: 'https://evil.example' },
+  });
+  assert.equal(publicHealth.status, 200);
+  assert.equal(publicHealth.headers.get('access-control-allow-origin'), null);
+
+  console.log('security regression checks passed');
+} finally {
+  setFreewayApiKey('');
+  await close(server);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { checkAllProvidersHealth, checkProviderHealth } from './health.js';
 import { loadAllModelCaches, refreshAllProviderModels } from './providers/index.js';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 8787;
+const HOST = process.env.HOST || '127.0.0.1';
 const WEB_ROOT = path.resolve(process.cwd(), 'src', 'web');
 const STATIC_ROOT = path.resolve(WEB_ROOT, 'static');
 const allowedEnvVars = new Set(listProviderEnvVars());
@@ -87,6 +88,54 @@ function sendStream(res: http.ServerResponse, status: number) {
 function sendNoContent(res: http.ServerResponse, allow: string) {
   res.writeHead(204, { Allow: allow });
   res.end();
+}
+
+function getHeader(req: http.IncomingMessage, name: string): string {
+  const value = req.headers[name.toLowerCase()];
+  return typeof value === 'string' ? value : '';
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+function isAllowedLocalOrigin(req: http.IncomingMessage): boolean {
+  const origin = getHeader(req, 'origin');
+  if (!origin) return false;
+
+  try {
+    const originUrl = new URL(origin);
+    return (originUrl.protocol === 'http:' || originUrl.protocol === 'https:') && isLocalHostname(originUrl.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function applyCorsHeaders(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+  const origin = getHeader(req, 'origin');
+  res.setHeader('Vary', 'Origin');
+
+  if (!origin) {
+    return true;
+  }
+
+  if (!isAllowedLocalOrigin(req)) {
+    return false;
+  }
+
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, HEAD, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key');
+  return true;
+}
+
+function isManagementRequest(pathname: string, method: string | undefined): boolean {
+  if (pathname === '/api/config/keys' && method === 'POST') return true;
+  if (pathname === '/api/models/refresh' && method === 'POST') return true;
+  if (pathname === '/api/health/check-all' && method === 'POST') return true;
+  if (pathname.startsWith('/api/health/check/') && method === 'POST') return true;
+  if (pathname === '/api/usage' && (method === 'GET' || method === 'DELETE')) return true;
+  return false;
 }
 
 async function readBody(req: http.IncomingMessage): Promise<string> {
@@ -173,16 +222,29 @@ function checkGatewayAuth(req: http.IncomingMessage, res: http.ServerResponse): 
   return true;
 }
 
+function checkManagementAccess(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+  const origin = getHeader(req, 'origin');
+  if (origin && !isAllowedLocalOrigin(req)) {
+    sendJSON(res, 403, {
+      error: {
+        message: 'Management APIs only accept same-machine browser origins.',
+        type: 'forbidden',
+      },
+    });
+    return false;
+  }
+
+  return checkGatewayAuth(req, res);
+}
+
 export function createServer(options: CreateServerOptions = {}): http.Server {
   const routeChatCompletion = options.routeChatCompletion ?? defaultRouteChatCompletion;
 
   return http.createServer(async (req, res) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, HEAD, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-api-key');
+  const corsAllowed = applyCorsHeaders(req, res);
 
   if (req.method === 'OPTIONS') {
-    res.writeHead(204);
+    res.writeHead(corsAllowed ? 204 : 403);
     res.end();
     return;
   }
@@ -197,6 +259,10 @@ export function createServer(options: CreateServerOptions = {}): http.Server {
   });
 
   try {
+    if (isManagementRequest(pathname, req.method) && !checkManagementAccess(req, res)) {
+      return;
+    }
+
     if (await serveStatic(pathname, res)) {
       return;
     }
@@ -585,8 +651,8 @@ export async function startServer() {
   });
 
   const server = createServer();
-  server.listen(PORT, () => {
-    console.log(`Free-Way running on http://localhost:${PORT}`);
+  server.listen(PORT, HOST, () => {
+    console.log(`Free-Way running on http://${HOST}:${PORT}`);
     console.log(`  GET  /`);
     console.log(`  GET  /api/catalog`);
     console.log(`  GET  /api/usage`);

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -14,6 +14,36 @@ const healthLabels = {
   unhealthy: 'Unhealthy',
 };
 
+const gatewayKeyStorageKey = 'freeway.gatewayKey';
+
+function getStoredGatewayKey() {
+  try {
+    return window.localStorage.getItem(gatewayKeyStorageKey) || '';
+  } catch {
+    return '';
+  }
+}
+
+function setStoredGatewayKey(value) {
+  try {
+    if (value) {
+      window.localStorage.setItem(gatewayKeyStorageKey, value);
+    } else {
+      window.localStorage.removeItem(gatewayKeyStorageKey);
+    }
+  } catch {
+    // Ignore storage failures; users can still rely on environment variables.
+  }
+}
+
+function withGatewayAuthHeaders(headers = {}, gatewayKey = getStoredGatewayKey()) {
+  const nextHeaders = new Headers(headers);
+  if (gatewayKey && !nextHeaders.has('Authorization') && !nextHeaders.has('x-api-key')) {
+    nextHeaders.set('Authorization', `Bearer ${gatewayKey}`);
+  }
+  return nextHeaders;
+}
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replaceAll('&', '&amp;')
@@ -24,10 +54,27 @@ function escapeHtml(value) {
 }
 
 async function fetchJSON(url, options) {
-  const response = await fetch(url, options);
+  const response = await fetch(url, {
+    ...options,
+    headers: withGatewayAuthHeaders(options?.headers ?? {}),
+  });
   if (!response.ok) {
     const payload = await response.json().catch(() => ({}));
     throw new Error(payload.error?.message ?? `Request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchJSONWithGatewayKey(url, options, gatewayKey) {
+  const response = await fetch(url, {
+    ...options,
+    headers: withGatewayAuthHeaders(options?.headers ?? {}, gatewayKey),
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const error = new Error(payload.error?.message ?? `Request failed: ${response.status}`);
+    error.status = response.status;
+    throw error;
   }
   return response.json();
 }
@@ -654,11 +701,26 @@ async function saveKeys() {
   const gatewayInput = document.getElementById('gateway-key');
   const gatewayKey = gatewayInput ? gatewayInput.value.trim() : '';
 
-  const result = await fetchJSON('/api/config/keys', {
+  const saveRequest = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ keys, gatewayKey }),
-  });
+  };
+
+  let result;
+  try {
+    result = await fetchJSON('/api/config/keys', saveRequest);
+  } catch (error) {
+    const storedGatewayKey = getStoredGatewayKey();
+    if (!gatewayKey || gatewayKey === storedGatewayKey || error.status !== 401) {
+      throw error;
+    }
+    result = await fetchJSONWithGatewayKey('/api/config/keys', saveRequest, gatewayKey);
+  }
+
+  if (gatewayInput) {
+    setStoredGatewayKey(gatewayKey);
+  }
 
   alert(`Saved ${result.updated.length} API key(s).`);
   await loadCatalog();
@@ -688,7 +750,7 @@ async function sendTestRequest() {
     if (stream) {
       const response = await fetch('/v1/chat/completions', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: withGatewayAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
           model,
           messages: [{ role: 'user', content: message }],
@@ -739,7 +801,7 @@ async function sendTestRequest() {
     } else {
       const response = await fetch('/v1/chat/completions', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: withGatewayAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
           model,
           messages: [{ role: 'user', content: message }],
@@ -859,6 +921,10 @@ function setupTabs() {
 
 function bindEvents() {
   setupEndpointCopyButtons();
+  const gatewayInput = document.getElementById('gateway-key');
+  if (gatewayInput) {
+    gatewayInput.value = getStoredGatewayKey();
+  }
   document.getElementById('model-search').addEventListener('input', renderModels);
   document.getElementById('model-sort').addEventListener('change', renderModels);
   document.getElementById('provider-search').addEventListener('input', renderProviders);


### PR DESCRIPTION
## Summary
- harden localhost management API access for #62
- restrict browser CORS to same-machine localhost origins instead of *
- protect management endpoints with the gateway auth path when FREEWAY_API_KEY is configured
- default the server bind host to 127.0.0.1, with HOST=0.0.0.0 as explicit LAN opt-in
- keep the web console working with gateway auth by carrying the local gateway key in browser requests
- sharpen the README hero positioning around free-tier BYOK usage

## Verification
- 
pm run build
- 
pm run test:security
- 
pm run test:usage
- 
pm run test:compat

## Review notes
Please review before merge. This PR is intentionally not merged yet so another team can check the security boundary and console auth flow.

Closes #62