### PR TITLE
docs: clarify local endpoint proxy limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,12 @@ These are ecosystem references, not hard dependencies. They help guide ongoing p
 
 ## Configure your agent
 
-Free-Way exposes **both** OpenAI and Anthropic compatible endpoints, so most coding agents and LLM clients can connect directly.
+Free-Way exposes **both** OpenAI and Anthropic compatible endpoints. Coding agents and LLM clients work best when they can call those custom base URLs directly from your machine.
 
 > Detailed per-agent setup guides are available in [`docs/agents/`](./docs/agents/).
 
 - [OpenRouter Provider Setup](./docs/providers/openrouter.md)
+- [Local endpoint and remote proxy limitations](./docs/agents/local-endpoints-and-remote-proxies.md)
 - [OpenCode setup guide](./docs/agents/opencode.md)
 - [Aider Integration Guide](./docs/agents/aider.md)
 
@@ -184,9 +185,9 @@ Then run `claude` normally. Free-Way routes Claude Code's Anthropic API calls to
 
 ### Cursor
 
-Cursor may not work with a localhost Free-Way endpoint. Some Cursor API flows are proxied through Cursor's servers before calling the configured API. In that setup, `localhost:8787` refers to Cursor's server environment, not your machine.
+Cursor is a known caveat for localhost endpoints. Some Cursor API flows may proxy requests through Cursor's servers before calling the configured API. In that setup, `localhost:8787` refers to Cursor's server environment, not your machine.
 
-Free-Way works best with clients that call custom OpenAI/Anthropic-compatible base URLs directly from your local machine.
+Free-Way works best with clients that call custom OpenAI/Anthropic-compatible base URLs directly from your local machine. See [Local endpoint and remote proxy limitations](./docs/agents/local-endpoints-and-remote-proxies.md) for the full explanation and a quick compatibility checklist.
 
 ### Continue.dev
 
@@ -215,9 +216,9 @@ export OPENAI_BASE_URL=http://localhost:8787/v1
 export OPENAI_API_KEY=<your FREEWAY_API_KEY>
 ```
 
-### Any other OpenAI/Anthropic client
+### Any other local-capable OpenAI/Anthropic client
 
-Point the base URL to `http://localhost:8787` (Anthropic) or `http://localhost:8787/v1` (OpenAI) and provide your gateway key if configured.
+If the client can call local custom base URLs directly, point it to `http://localhost:8787` (Anthropic) or `http://localhost:8787/v1` (OpenAI) and provide your gateway key if configured.
 
 ### API key precedence
 

--- a/docs/agents/local-endpoints-and-remote-proxies.md
+++ b/docs/agents/local-endpoints-and-remote-proxies.md
@@ -1,0 +1,65 @@
+# Local Endpoints and Remote Proxies
+
+Free-Way is local-first. It runs on your computer and exposes local OpenAI- and Anthropic-compatible endpoints:
+
+- OpenAI-compatible: `http://localhost:8787/v1`
+- Anthropic-compatible: `http://localhost:8787`
+
+This works well when your AI client sends API requests directly from your machine to Free-Way. It may not work when the client first sends those requests to its own remote service and that remote service calls the configured API URL on your behalf.
+
+## Why `localhost` can point to the wrong place
+
+`localhost` always means "this machine" from the point of view of the process making the HTTP request.
+
+When a local CLI, editor extension, or desktop app calls Free-Way directly, `localhost:8787` means your computer. The request reaches your local Free-Way server, and Free-Way can route it to the providers you have configured.
+
+When a client proxies the request through a remote server first, the remote server becomes the process making the HTTP request. In that case, `localhost:8787` means the remote server's own environment, not your computer. Your Free-Way process is still running locally, but the remote service cannot see it at that address.
+
+That distinction is the important part:
+
+- Direct local request: `client on your machine -> localhost:8787 -> Free-Way`
+- Remote-proxied request: `client -> remote service -> localhost:8787 on the remote service`
+
+Free-Way cannot make a third-party remote service reach a private `localhost` address on your machine. For the local-first setup, the client needs to call the custom base URL directly from the same machine or environment where Free-Way is running.
+
+## Cursor caveat
+
+Cursor is a known example to check carefully. Some Cursor API flows may proxy requests through Cursor-controlled servers before calling the configured API endpoint. In those flows, `localhost:8787` refers to Cursor's remote environment, so a local Free-Way endpoint may not be reachable.
+
+This does not mean every Cursor feature, version, or configuration behaves the same way. Treat Cursor as a caveat: verify the exact flow you are using before assuming a local Free-Way endpoint will work.
+
+## What Free-Way supports
+
+Free-Way supports clients that can call custom OpenAI- or Anthropic-compatible base URLs directly from your local machine, local shell, local editor process, or another environment that can actually reach the Free-Way server.
+
+Free-Way does not claim support for clients that only call model APIs from a vendor-hosted backend and cannot directly reach your local endpoint.
+
+You can expose a local service through a tunnel or public URL, but that changes the security model. Free-Way's default setup assumes local access, local provider keys, and a private `localhost` gateway.
+
+## Quick compatibility checklist
+
+Use this checklist when testing a new client:
+
+- Can the client set a custom OpenAI or Anthropic base URL?
+- Is the API request sent by a process running on your machine, rather than by the client's cloud service?
+- Can the client use `http://localhost:8787/v1` for OpenAI-compatible calls or `http://localhost:8787` for Anthropic-compatible calls?
+- After sending a test prompt, does Free-Way show the request in its console or terminal logs?
+- If the client fails, does a direct local command such as `curl http://localhost:8787/v1/models` still work from the same shell or environment?
+- Does the client documentation mention server-side API calls, cloud execution, remote agents, hosted gateways, or provider-side proxying?
+
+If `curl` works locally but the client never reaches Free-Way, the client may not be making the request from the same machine. It may be using a remote proxy, a hosted workspace, a container, WSL, or another isolated environment where `localhost` means something else.
+
+## A simple test
+
+Start Free-Way, then verify the local endpoint from your machine:
+
+```bash
+curl http://localhost:8787/v1/models
+```
+
+Then configure the client with the matching base URL:
+
+- OpenAI-compatible clients: `http://localhost:8787/v1`
+- Anthropic-compatible clients: `http://localhost:8787`
+
+Send a small test prompt. If Free-Way records the request, the client can reach the local endpoint. If Free-Way records nothing, the request is likely not arriving at your local gateway, and the client may need a different networking setup or may not be compatible with a private localhost endpoint.


### PR DESCRIPTION
## Summary

This PR documents an important local networking limitation for Free-Way users: some clients may not be able to use `http://localhost:8787` when their API requests are routed through remote servers before reaching the configured base URL.

Free-Way is designed as a local-first gateway. It works best when the client calls the OpenAI- or Anthropic-compatible endpoint directly from the same machine where Free-Way is running.

## What changed

- Added a new documentation page: `docs/agents/local-endpoints-and-remote-proxies.md`
- Explained why `localhost:8787` can point to the wrong environment when a client proxies requests through a remote service
- Added a clear direct-request vs remote-proxied-request comparison
- Documented Cursor as a known caveat without claiming that every Cursor flow behaves the same way
- Clarified that Free-Way supports clients that can directly reach local custom base URLs
- Added a short compatibility checklist for users testing new clients
- Linked the new page from the README agent configuration section
- Updated the README wording to avoid implying support for clients that cannot reach local endpoints

## Why this matters

Users may configure a client with `http://localhost:8787` and expect it to reach their local Free-Way instance. That works when the request is made from the user's machine.

However, if the client sends the request through its own remote backend first, `localhost` no longer refers to the user's computer. It refers to the remote environment making the final HTTP request. In that setup, the local Free-Way server is not reachable through `localhost:8787`.

This documentation makes that behavior explicit and gives users a practical way to verify whether a client is compatible with Free-Way's local-first setup.

## Verification

- Confirmed the new page explains the local endpoint/proxy behavior in plain language
- Confirmed Cursor is mentioned as a caveat without overclaiming that all Cursor flows behave the same way
- Confirmed the documentation avoids claiming support for clients that cannot directly reach local endpoints
- Confirmed the new page includes a quick compatibility checklist
- Confirmed the README links to the new documentation page from the agent setup section

## Notes

This is a documentation-only change. No runtime behavior, provider routing, API compatibility code, or tests were changed.
