### PR TITLE
fix: persist empty usage list to disk when clearing records

### DIFF
--- a/scripts/verify-clear-fix.mjs
+++ b/scripts/verify-clear-fix.mjs
@@ -1,0 +1,42 @@
+/**
+ * Manual verification script for issue #27 fix:
+ * "Persist cleared usage records to disk"
+ *
+ * Tests that clear() writes an empty list to .freeway/usage.json
+ * so usage does not come back after a restart.
+ */
+import { readFile } from 'fs/promises';
+import path from 'path';
+import assert from 'node:assert/strict';
+import { usageTracker } from '../dist/usage-tracker.js';
+
+const cacheFile = path.resolve(process.cwd(), '.freeway', 'usage.json');
+
+// ── Step 1: record some usage (flush is async, wait a tick) ─────────────────
+await usageTracker.init();
+usageTracker.record('gpt-4o', 'test-provider', 100, 50);
+await new Promise(r => setTimeout(r, 200)); // let the background flush finish
+
+const before = JSON.parse(await readFile(cacheFile, 'utf-8'));
+assert.equal(before.length, 1, 'Expected 1 record on disk before clear()');
+console.log('✓ Usage written to disk:', before[0].modelId, '/ callCount:', before[0].callCount);
+
+// ── Step 2: clear usage ──────────────────────────────────────────────────────
+const returned = await usageTracker.clear();
+assert.equal(returned.length, 1, 'clear() must return the cleared records');
+console.log('✓ clear() returned', returned.length, 'record(s)');
+
+// ── Step 3: disk must now be empty (this was the bug) ───────────────────────
+const afterClear = JSON.parse(await readFile(cacheFile, 'utf-8'));
+assert.equal(afterClear.length, 0, 'BUG: disk still has records after clear()');
+console.log('✓ Disk is empty after clear() — fix confirmed');
+
+// ── Step 4: in-memory state is also empty ───────────────────────────────────
+assert.equal(usageTracker.getStats().length, 0, 'In-memory records must be cleared too');
+console.log('✓ In-memory records cleared');
+
+// ── Step 5: response shape unchanged ────────────────────────────────────────
+assert.ok(Array.isArray(returned), 'clear() must return an array (response shape compat)');
+console.log('✓ Response shape compatible (returns UsageRecord[])');
+
+console.log('\nAll checks passed — bug fix verified!');

--- a/src/server.ts
+++ b/src/server.ts
@@ -303,7 +303,8 @@ export function createServer(options: CreateServerOptions = {}): http.Server {
     }
 
     if (pathname === '/api/usage' && req.method === 'DELETE') {
-      sendJSON(res, 200, { records: usageTracker.clear() });
+      const records = await usageTracker.clear();
+      sendJSON(res, 200, { records });
       return;
     }
 

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -72,9 +72,11 @@ class UsageTracker {
     return Array.from(this.records.values()).sort((a, b) => b.lastUsedAt - a.lastUsedAt);
   }
 
-  clear(): UsageRecord[] {
+  async clear(): Promise<UsageRecord[]> {
     const records = Array.from(this.records.values());
     this.records.clear();
+    // Persist the empty state so usage does not reappear after a restart.
+    await this.flush();
     return records;
   }
 


### PR DESCRIPTION
## Summary

Fixes #27

`UsageTracker.clear()` only cleared the in-memory map but never called `flush()`, so the old records in `.freeway/usage.json` survived a server restart - causing usage to reappear.

## Root cause

`clear()` was synchronous and did not persist the empty state:

`	s
// before
clear(): UsageRecord[] {
  const records = Array.from(this.records.values());
  this.records.clear();
  return records; // flush() never called!
}
`

## Fix

Made `clear()` async and call `flush()` before returning. Updated the `DELETE /api/usage` route in `server.ts` to `await` the result:

`	s
// after
async clear(): Promise<UsageRecord[]> {
  const records = Array.from(this.records.values());
  this.records.clear();
  await this.flush(); // persists empty list immediately
  return records;
}
`

## Verification

All existing regression tests pass:

`
npm run test:usage    ? usage regression checks passed
npm run test:compat   ? compat regression checks passed
npm run test:security ? security regression checks passed
`

Manual end-to-end check (`node scripts/verify-clear-fix.mjs`):

`
? Usage written to disk: gpt-4o / callCount: 1
? clear() returned 1 record(s)
? Disk is empty after clear() - fix confirmed
? In-memory records cleared
? Response shape compatible (returns UsageRecord[])

All checks passed - bug fix verified!
`

## Checklist

- [x] Persist empty usage list after `clear()`
- [x] `DELETE /api/usage` response shape unchanged (still returns `{ records: UsageRecord[] }`)
- [x] No new dependencies added
- [x] `npm run build` passes
- [x] PR focused on this bug only