### PR TITLE
feat: add npm CLI package entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@
 ### 1. Install and launch
 
 ```bash
+npx @godiao/free-way
+```
+
+Or install it globally:
+
+```bash
+npm install -g @godiao/free-way
+freeway
+```
+
+For local development:
+
+```bash
 git clone https://github.com/GoDiao/Free-Way.git
 cd Free-Way
 npm install

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,6 +57,19 @@
 ### 1. 安装并启动
 
 ```bash
+npx @godiao/free-way
+```
+
+也可以全局安装：
+
+```bash
+npm install -g @godiao/free-way
+freeway
+```
+
+本地开发：
+
+```bash
 git clone https://github.com/GoDiao/Free-Way.git
 cd Free-Way
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "freeway",
+  "name": "@godiao/free-way",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "freeway",
+      "name": "@godiao/free-way",
       "version": "0.1.0",
       "license": "MIT",
+      "bin": {
+        "freeway": "dist/index.js"
+      },
       "dependencies": {
         "undici": "^8.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
-  "name": "freeway",
+  "name": "@godiao/free-way",
   "version": "0.1.0",
   "description": "OpenAI-compatible router for free LLM APIs",
   "main": "dist/index.js",
+  "bin": {
+    "freeway": "dist/index.js"
+  },
   "type": "module",
+  "files": [
+    "dist",
+    "src/web/static",
+    "src/web/templates"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { startServer } from './server.js';
 
 void startServer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { readFile } from 'fs/promises';
 import type { ChatCompletionRequest } from './types.js';
 import { routeChatCompletion as defaultRouteChatCompletion } from './router.js';
@@ -15,7 +16,7 @@ import { usageTracker } from './usage-tracker.js';
 
 // Configure HTTP proxy for all fetch() calls if HTTP_PROXY is set
 try {
-  // @ts-ignore â€” undici is bundled with Node.js 18+
+  // @ts-ignore â€?undici is bundled with Node.js 18+
   const undici = await import('undici');
   if (process.env.HTTP_PROXY && undici.ProxyAgent && undici.setGlobalDispatcher) {
     undici.setGlobalDispatcher(new undici.ProxyAgent(process.env.HTTP_PROXY));
@@ -32,7 +33,9 @@ import { loadAllModelCaches, refreshAllProviderModels } from './providers/index.
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 8787;
 const HOST = process.env.HOST || '127.0.0.1';
-const WEB_ROOT = path.resolve(process.cwd(), 'src', 'web');
+const DIST_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.dirname(DIST_ROOT);
+const WEB_ROOT = path.resolve(PACKAGE_ROOT, 'src', 'web');
 const STATIC_ROOT = path.resolve(WEB_ROOT, 'static');
 const allowedEnvVars = new Set(listProviderEnvVars());
 const DEBUG_TRACE = process.env.FREEWAY_DEBUG_TRACE === '1';


### PR DESCRIPTION
## Summary
- publish package as @godiao/free-way
- add freeway npm bin entry for global installs
- resolve packaged web asset paths from package root
- document npx/global install commands

## Validation
- npm run build
- npm pack --dry-run --registry=https://registry.npmjs.org/